### PR TITLE
Change the skybox name references to lowercase

### DIFF
--- a/export_shared.py
+++ b/export_shared.py
@@ -937,7 +937,7 @@ class SceneToTHPSLevel(bpy.types.Operator):
     generate_col_file: BoolProperty(name="Generate a .col file", default=True)
     generate_scripts_files: BoolProperty(name="Generate scripts", default=True)
 
-    skybox_name: StringProperty(name="Skybox name", default="THUG_Sky")
+    skybox_name: StringProperty(name="Skybox name", default="THUG_sky")
     export_scale: FloatProperty(name="Export scale", default=1)
     
     max_texture_size: IntProperty(name="Max Texture Size"


### PR DESCRIPTION
Change the skybox file name references to lower case so that case-sensitive operating systems won't throw a fit about not finding the skybox file.