### PR TITLE
Add missing thugpro level manifest flags

### DIFF
--- a/level_manifest.py
+++ b/level_manifest.py
@@ -58,7 +58,9 @@ def export_level_manifest_json(filename, directory, operator, level_info):
         outp.write("\t\"FLAG_DISABLE_GOALATTACK\": {},\n".format(("true" if level_info.level_flag_nogoalattack else "false")))
         outp.write("\t\"FLAG_NO_PRX\": {},\n".format(("true" if level_info.level_flag_noprx else "false")))
         outp.write("\t\"FLAG_IS_BIG_LEVEL\": {},\n".format(("true" if level_info.level_flag_biglevel else "false")))
-
+        outp.write("\t\"FLAG_IS_TALL_LEVEL\": {},\n".format(("true" if level_info.level_flag_tall else "false")))
+        outp.write("\t\"FLAG_HAS_CLASSIC_GOALS\": {},\n".format(("true" if level_info.level_flag_classicgoals else "false")))
+        
         outp.write("}\n")
 
 
@@ -180,6 +182,7 @@ class THUG_PT_SceneSettings(bpy.types.Panel):
         box = self.layout.box().column(align=True)
         box.row().prop(scene.thug_level_props, "level_flag_offline")
         box.row().prop(scene.thug_level_props, "level_flag_biglevel")
+        box.row().prop(scene.thug_level_props, "level_flag_tall")
         box.row().prop(scene.thug_level_props, "level_flag_noprx")
         box.row().prop(scene.thug_level_props, "level_flag_indoor")
         box.row().prop(scene.thug_level_props, "level_flag_nosun")
@@ -187,5 +190,6 @@ class THUG_PT_SceneSettings(bpy.types.Panel):
         box.row().prop(scene.thug_level_props, "level_flag_wallridehack")
         box.row().prop(scene.thug_level_props, "level_flag_nobackfacehack")
         box.row().prop(scene.thug_level_props, "level_flag_modelsinprx")
+        box.row().prop(scene.thug_level_props, "level_flag_classicgoals")
         box.row().prop(scene.thug_level_props, "level_flag_nogoaleditor")
         box.row().prop(scene.thug_level_props, "level_flag_nogoalattack")

--- a/scene_props.py
+++ b/scene_props.py
@@ -985,16 +985,18 @@ class THUGLevelProps(bpy.types.PropertyGroup):
     level_light1_headpitch: FloatVectorProperty(name="Heading/Pitch", size=2, soft_min=0, soft_max=360, default=(0, 0))
     
     level_flag_offline: BoolProperty(name="Offline Only", description="This level is not enabled for online play", default=False)
-    level_flag_indoor: BoolProperty(name="Indoor", description="(THUG PRO only) This level is indoor", default=False)
-    level_flag_nosun: BoolProperty(name="No Sun", description="(THUG PRO only) Don't display the dynamic sun in this level", default=False)
-    level_flag_defaultsky: BoolProperty(name="Default Sky", description="(THUG PRO only) Use the default skybox", default=False)
-    level_flag_wallridehack: BoolProperty(name="Wallride Hack", description="(THUG PRO only) Automatically makes all walls wallridable", default=False)
-    level_flag_nobackfacehack: BoolProperty(name="No Backface Hack", description="(THUG PRO only)", default=False)
-    level_flag_modelsinprx: BoolProperty(name="Models in scripts .prx", description="(THUG PRO only)", default=False)
-    level_flag_nogoaleditor: BoolProperty(name="Disable goal editor", description="(THUG PRO only)", default=False)
-    level_flag_nogoalattack: BoolProperty(name="Disable goal attack", description="(THUG PRO only)", default=False)
-    level_flag_noprx: BoolProperty(name="Don't use prx files", description="(THUG PRO only) This level uses uncompressed files, not packed in .prx files", default=False)
-    level_flag_biglevel: BoolProperty(name="Big Level", description="(THUG PRO only) Use extended online position broadcast limits", default=False)
+    level_flag_indoor: BoolProperty(name="Indoor", description="(THUG PRO) This level is indoor", default=False)
+    level_flag_nosun: BoolProperty(name="No Sun", description="(THUG PRO) Don't display the dynamic sun in this level", default=False)
+    level_flag_defaultsky: BoolProperty(name="Default Sky", description="(THUG PRO) Use the default skybox", default=False)
+    level_flag_wallridehack: BoolProperty(name="Wallride Hack", description="(THUG PRO) Automatically makes all walls wallridable", default=False)
+    level_flag_nobackfacehack: BoolProperty(name="No Backface Hack", description="(THUG PRO)", default=False)
+    level_flag_modelsinprx: BoolProperty(name="Models in scripts .prx", description="(THUG PRO)", default=False)
+    level_flag_nogoaleditor: BoolProperty(name="Disable Goal Editor", description="(THUG PRO)", default=False)
+    level_flag_nogoalattack: BoolProperty(name="Disable Goal Attack", description="(THUG PRO)", default=False)
+    level_flag_noprx: BoolProperty(name="Don't use prx files", description="(THUG PRO) This level uses uncompressed files, not packed in .prx files", default=False)
+    level_flag_biglevel: BoolProperty(name="Big Level", description="(THUG PRO) Use extended horizontal position limits for online broadcast, reduces accuracy", default=False)
+    level_flag_tall: BoolProperty(name="Tall Level", description="(THUG PRO) Use extended vertical position limits for online broadcast, reduces accuracy", default=False)
+    level_flag_classicgoals: BoolProperty(name="Classic Goals", description="(THUG PRO) This level has classic goals", default=False)
     
 # METHODS
 #############################################


### PR DESCRIPTION
Added these missing THUG PRO level manifest flags:

- `FLAG_IS_TALL_LEVEL`
Use extended vertical position limits for online broadcast, reduces skater's positional accuracy (use only if have to)

- `FLAG_HAS_CLASSIC_GOALS`
This level has classic goals

Also clarified that `FLAG_IS_BIG_LEVEL` affects *horizontal* position limits.

Note that I don't have Blender nor did test the changes, I just stumbled upon this repo randomly and noticed the flags missing. So you should test that the added checkboxes fit properly in the UI, because I did not :)
